### PR TITLE
fix: markup syntax

### DIFF
--- a/lnPoSTdisplay/libraries/PageBuilder/README.md
+++ b/lnPoSTdisplay/libraries/PageBuilder/README.md
@@ -218,7 +218,7 @@ PageElement::PageElement(const __FlashStringHelper* mold, TokenVT source);
   ```c++
   String func1(PageArgument& args);
   String func2(PageArgument& args);
-  PageElement elem(html, {{"TOKEN1", func1}, {"TOKEN2", func2}});
+  PageElement elem(html, {{"TOKEN1", func1}}, {"TOKEN2", func2}});
   ```
   `mold` can also use external files placed on [LittleFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs) or [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs). Since HTML consists of more strings, the program area may be smaller in sketches using many pages.  
   External files can have HTML source specified by `mold`. That file would be allocated on the LittleFS or SPIFFS file system. This allows you to reduce the sketch size and assign more capacity to the program.  


### PR DESCRIPTION
Side effect in GitHub pages:

![image](https://user-images.githubusercontent.com/2951406/190106305-07bbee82-0917-4f1e-a853-45ff997d33b5.png)
