### PR TITLE
fixes to improve parsing of JSON response

### DIFF
--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -1454,18 +1454,14 @@ bool getSats()
                "\r\n" +
                toPost + "\n");
 
-  while (client.connected())
-  {
-    const String line = client.readStringUntil('\n');
-    if (line == "\r")
-    {
-      break;
-    }
-  }
+  String line = client.readString();
+  int locStart = line.indexOf("{");
+  int locFinish = line.indexOf("}", locStart);
+  String line =  line.substring(locStart, locFinish+1);
 
-  const String line = client.readString();
   StaticJsonDocument<150> doc;
   DeserializationError error = deserializeJson(doc, line);
+  
   if (error)
   {
     Serial.print("deserializeJson() failed: ");
@@ -1509,20 +1505,15 @@ bool getInvoice()
                "Content-Length: " + toPost.length() + "\r\n" +
                "\r\n" +
                toPost + "\n");
-
-  while (client.connected())
-  {
-    const String line = client.readStringUntil('\n');
-
-    if (line == "\r")
-    {
-      break;
-    }
-  }
-  const String line = client.readString();
+  
+  String line = client.readString();
+  int locStart = line.indexOf("{");
+  int locFinish = line.lastIndexOf("}");
+  String line =  line.substring(locStart, locFinish+1);
 
   StaticJsonDocument<1000> doc;
   DeserializationError error = deserializeJson(doc, line);
+  
   if (error)
   {
     Serial.print("deserializeJson() failed: ");
@@ -1559,20 +1550,15 @@ bool checkInvoice()
                "User-Agent: ESP32\r\n" +
                "Content-Type: application/json\r\n" +
                "Connection: close\r\n\r\n");
-  while (client.connected())
-  {
-    const String line = client.readStringUntil('\n');
-    if (line == "\r")
-    {
-      break;
-    }
-  }
+  
+  String line = client.readString();
+  int locStart = line.indexOf("{");
+  int locFinish = line.lastIndexOf("}");
+  String line =  line.substring(locStart, locFinish+1);
 
-  const String line = client.readString();
-  Serial.println(line);
   StaticJsonDocument<2000> doc;
-
   DeserializationError error = deserializeJson(doc, line);
+  
   if (error)
   {
     Serial.print("deserializeJson() failed: ");


### PR DESCRIPTION
As discussed in the Telegram chat: After April 1st 2023 I've started having some issues with the JSON returned by lnbits, the input was flagged as invalid. I've added this code to first select the data between {}, and then run the parser to get the JSON in the right format.  I'm skipping the -- while (client.connected()) -- because in my code was not mandatory, but I acknowledge it could be a good practice to keep it. Hope this fix helps!