### PR TITLE
Minor fixes and improvements

### DIFF
--- a/lnpos/100_config.ino
+++ b/lnpos/100_config.ino
@@ -164,7 +164,7 @@ void readFiles()
       secretATM = getValue(lnurlATM, ',', 1);
       currencyATM = getValue(lnurlATM, ',', 2);
       Serial.println("");
-      Serial.println("lnurlPoS: " + lnurlPoS);
+      Serial.println("lnurlATM: " + lnurlATM);
       if (secretATM != "")
       {
         menuItemCheck[3] = 1;

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -1,0 +1,3 @@
+0.0.14
+======
+- Fix copy-paste typo with logging 'lnurlATM' configuration to serial

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -2,3 +2,4 @@
 ======
 - Fix copy-paste typo with logging 'lnurlATM' configuration to serial
 - Remove unused WebServer to reduce build time, file size and installation time
+- Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Fix copy-paste typo with logging 'lnurlATM' configuration to serial
 - Remove unused WebServer to reduce build time, file size and installation time
 - Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present
+- Make "USB" indicator blue so it looks better and is easier to recognize

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -1,6 +1,7 @@
-0.0.14
+0.1.4
 ======
 - Fix copy-paste typo with logging 'lnurlATM' configuration to serial
 - Remove unused WebServer to reduce build time, file size and installation time
 - Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present
 - Make "USB" indicator blue so it looks better and is easier to recognize
+- Show firmware version at boot to easily check which version the user is running when troubleshooting in the field

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -1,3 +1,4 @@
 0.0.14
 ======
 - Fix copy-paste typo with logging 'lnurlATM' configuration to serial
+- Remove unused WebServer to reduce build time, file size and installation time

--- a/lnpos/CHANGELOG.md
+++ b/lnpos/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.1.4
 ======
-- Fix copy-paste typo with logging 'lnurlATM' configuration to serial
+- Fix typo with logging 'lnurlATM' configuration to serial
 - Remove unused WebServer to reduce build time, file size and installation time
-- Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present
-- Make "USB" indicator blue so it looks better and is easier to recognize
-- Show firmware version at boot to easily check which version the user is running when troubleshooting in the field
+- Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present (or when the user is color blind)
+- Make "USB" indicator blue so it looks better and is easier to distinguish
+- Show firmware version at boot to allow the user to easily check which version is running (handy for troubleshooting)

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -16,6 +16,7 @@ fs::SPIFFSFS &FlashFS = SPIFFS;
 #include <Keypad.h>
 #include <ArduinoJson.h>
 
+#define VERSION "0.1.4"
 #define PARAM_FILE "/elements.json"
 #define KEY_FILE "/thekey.txt"
 #define USB_POWER 1000 // battery percentage sentinel value to indicate USB power
@@ -1121,6 +1122,7 @@ void logo()
   tft.print("PoS");
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   tft.setTextSize(2);
+  tft.print(VERSION);
   tft.setCursor(0, 80);
   tft.print("Powered by LNbits");
 }

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -1289,13 +1289,14 @@ void menuLoop()
         {
           tft.setTextColor(TFT_GREEN, TFT_BLACK);
           selection = menuItems[i];
+          tft.print("-> ");
         }
         else
         {
           tft.setTextColor(TFT_WHITE, TFT_BLACK);
+          tft.print("   ");
         }
 
-        tft.print("  ");
         tft.println(menuItems[i]);
         menuItemCount++;
       }

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -1,9 +1,7 @@
 #include <WiFi.h>
-#include <WebServer.h>
 #include <FS.h>
 #include <SPIFFS.h>
 #include <math.h>
-using WebServerClass = WebServer;
 fs::SPIFFSFS &FlashFS = SPIFFS;
 #define FORMAT_ON_FAIL true
 #include <Keypad.h>

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -10,7 +10,8 @@ fs::SPIFFSFS &FlashFS = SPIFFS;
 #include "qrcoded.h"
 #include <WiFiClientSecure.h>
 
-// ArduinoJson, Keypad and uBitcoin should be installed using the Arduino Library manager:
+// ArduinoJson, Keypad and uBitcoin should be installed using the Arduino Library Manager.
+// The latest versions should work, verified with ArduinoJson 7.2.1, Keypad 3.1.1 and uBitcoin 0.2.0
 #include <Hash.h>
 #include <Bitcoin.h>
 #include <Keypad.h>

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -1142,7 +1142,7 @@ void updateBatteryStatus(bool force = false)
   String batteryPercentageText = "";
   if (batteryPercentage == USB_POWER)
   {
-    tft.setTextColor(TFT_GREEN, TFT_BLACK);
+    tft.setTextColor(TFT_BLUE, TFT_BLACK);
     batteryPercentageText = " USB";
   }
   else

--- a/lnpos/lnpos.ino
+++ b/lnpos/lnpos.ino
@@ -4,15 +4,17 @@
 #include <math.h>
 fs::SPIFFSFS &FlashFS = SPIFFS;
 #define FORMAT_ON_FAIL true
-#include <Keypad.h>
 #include <SPI.h>
 #include <TFT_eSPI.h>
-#include <Hash.h>
-#include <ArduinoJson.h>
 #include <stdio.h>
 #include "qrcoded.h"
-#include "Bitcoin.h"
 #include <WiFiClientSecure.h>
+
+// ArduinoJson, Keypad and uBitcoin should be installed using the Arduino Library manager:
+#include <Hash.h>
+#include <Bitcoin.h>
+#include <Keypad.h>
+#include <ArduinoJson.h>
 
 #define PARAM_FILE "/elements.json"
 #define KEY_FILE "/thekey.txt"


### PR DESCRIPTION
These are a few minor fixes and small improvements:
- Fix typo with logging 'lnurlATM' configuration to serial
- Remove unused WebServer to reduce build time, file size and installation time
- Show a little "arrow" in front of the selected menu item to avoid ambiguity when only 2 menu items are present (or when the user is color blind)
- Make "USB" indicator blue so it looks better and is easier to distinguish
- Show firmware version at boot to allow the user to easily check which version is running (handy for troubleshooting)

I also added a CHANGELOG.md where developers can list the (user-relevant) changes they're making, so that whoever releases the next version can copy-paste them into the GitHub "releases" page, so that  users can easily weigh the benefits of upgrading and know what to expect, without having to go into the more technical list of commits.